### PR TITLE
input-stream not returning a map for file URL

### DIFF
--- a/src/pl/danieljanus/tagsoup.clj
+++ b/src/pl/danieljanus/tagsoup.clj
@@ -47,7 +47,7 @@
 
 (defmethod input-stream URL [#^URL x]
   (if (= "file" (.getProtocol x))
-    (FileInputStream. (.getPath x))
+    (input-stream (File. (.getPath x)))
     (let [connection (.openConnection x)]
       {:stream (.getInputStream connection), :encoding (-> connection (.getHeaderField "Content-Type") encoding-from-content-type)})))
 


### PR DESCRIPTION
`input-stream` on a file URL is returning the stream, instead of a map with a `:stream` key like the other methods.

Before:

```
pl.danieljanus.tagsoup> (input-stream (clojure.java.io/resource "scores.html"))
#<FileInputStream java.io.FileInputStream@5ce345c2>
```

After:

```
pl.danieljanus.tagsoup> (input-stream (clojure.java.io/resource "scores.html"))
{:stream #<FileInputStream java.io.FileInputStream@26ffd553>}
```

Fixed by delegating to the File method, so a file URL is always treated like a File.
