### PR TITLE
lazy xml parsing and compatibility with clojure >= 1.3.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
 (defproject clj-tagsoup "0.2.6"
   :description "A HTML parser for Clojure."
-  :dependencies [[clojure "1.2.0"]
-                 [org.clojure/clojure-contrib "1.2.0"]
+  :dependencies [[org.clojure/clojure "[1.2.0,)"]
+                 [org.clojure/data.xml "0.0.3"]
                  [org.clojars.nathell/tagsoup "1.2.1"]]
   :dev-dependencies [[swank-clojure "1.2.0"]])

--- a/src/pl/danieljanus/tagsoup.clj
+++ b/src/pl/danieljanus/tagsoup.clj
@@ -1,7 +1,7 @@
 (ns pl.danieljanus.tagsoup
   (:require [clojure.zip :as zip]
             [clojure.xml :as xml]
-            [clojure.contrib.lazy-xml :as lazy-xml])
+            [clojure.data.xml :as lazy-xml])
   (:import (org.ccil.cowan.tagsoup Parser)
            (java.net URI URL MalformedURLException Socket)
            (java.io InputStream File FileInputStream ByteArrayInputStream BufferedInputStream InputStreamReader BufferedReader)


### PR DESCRIPTION
These changes allow for lazy parsing of the XML structure.
