### PR TITLE
Bump data.xml so the library will work with clojure 1.9.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
 (defproject clj-tagsoup "0.3.0"
   :description "A HTML parser for Clojure."
   :dependencies [[org.clojure/clojure "[1.2.0,)"]
-                 [org.clojure/data.xml "0.0.3"]
+                 [org.clojure/data.xml "0.0.8"]
                  [org.clojars.nathell/tagsoup "1.2.1"]
                  [net.java.dev.stax-utils/stax-utils "20040917"]])

--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
 (defproject clj-tagsoup "0.3.0"
   :description "A HTML parser for Clojure."
-  :dependencies [[org.clojure/clojure "[1.2.0,)"]
+  :dependencies [[org.clojure/clojure "1.2.0"]
                  [org.clojure/data.xml "0.0.8"]
                  [org.clojars.nathell/tagsoup "1.2.1"]
                  [net.java.dev.stax-utils/stax-utils "20040917"]])

--- a/test/pl/danieljanus/tagsoup_test.clj
+++ b/test/pl/danieljanus/tagsoup_test.clj
@@ -1,0 +1,8 @@
+(ns pl.danieljanus.tagsoup-test
+  (:use
+   pl.danieljanus.tagsoup
+   clojure.test))
+
+(deftest parse-string-test
+  (is (= [:html {} [:body {} [:p {} "foo"]]]
+         (parse-string "<p>foo</p>"))))


### PR DESCRIPTION
data.xml 0.0.3 has a malformed defn somewhere that won't compile with 1.9.0-alpha12 because defn got spec'd. see #18 Bumped it to 0.0.8 which is the latest stable version. Also started on a test suite to see if anything broke.