### PR TITLE
bump version of data.xml to 0.0.8

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
 (defproject clj-tagsoup "0.3.0"
   :description "A HTML parser for Clojure."
   :dependencies [[org.clojure/clojure "[1.2.0,)"]
-                 [org.clojure/data.xml "0.0.3"]
+                 [org.clojure/data.xml "0.0.8"]
                  [org.clojars.nathell/tagsoup "1.2.1"]
                  [net.java.dev.stax-utils/stax-utils "20040917"]])


### PR DESCRIPTION
To work with clojure 1.10 I needed to bump the version of data.xml.

This resolves the issue #18 

https://github.com/nathell/clj-tagsoup/issues/18
